### PR TITLE
Show that NetworkInterface.Description varies significantly across operating systems

### DIFF
--- a/xml/System.Net.NetworkInformation/NetworkInterface.xml
+++ b/xml/System.Net.NetworkInformation/NetworkInterface.xml
@@ -102,7 +102,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The description is human-readable text that typically describes the interface vendor, type (for example, Ethernet), brand, and model.  
+ The description is human-readable text that describes the network interface. The information included in the description depends on the capabilities of the operating system.  On Windows, it typically describes the interface vendor, type (for example, Ethernet), brand, and model.  On other platforms, it may be as brief as the name of the interface, e.g. `eth0`.
   
    
   


### PR DESCRIPTION
Show that NetworkInterface.Description varies, significantly, across operating systems and therefore may not include detailed information. 

## Summary

On Linux, Description is just the name of the interface, such as `eth0`.  That's necessary because Linux doesn't actually _have_ descriptive text available in the OS. It just has numbers.  There are tools that can be installed on Linux that come with databases to look those numbers up and translate them to text, but those tools cannot be relied on to be present.  So the .NET Core team had to fall back to just providing something simple in the Description, and they chose the name of the interface.

The change I made prevents users from mistakenly expecting the description is likely to provide rich information on all platforms.

## Details

See https://github.com/dotnet/corefx/issues/26248


